### PR TITLE
Add quotes and style format

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports = function() {
       var fontToBase64 = new Buffer(file.contents).toString('base64'),
           fileName = path.basename(file.path, path.extname(file.path)),
           styleRules = {
+            extrabold:  "font-weight: 800;",
             black:      "font-weight: 800;",
             bold:       "font-weight: 700;",
             semibold:   "font-weight: 600;",
@@ -35,7 +36,7 @@ module.exports = function() {
           // Filenames should be of the style: FontFamily-Style1-Style2...
           fontAttrs = fileName.split('-'),
           fontFamily = fontAttrs.shift(),
-          css = '@font-face { font-family: ' + fontFamily + '; ';
+          css = '@font-face { font-family: \'' + fontFamily + '\'; ';
 
       css += fontAttrs.map(function(attr) {
         // Format our font attributes
@@ -44,7 +45,7 @@ module.exports = function() {
         return styleRules[attr] ? prev + ' ' + styleRules[attr] : prev;
       }, String());
 
-      css += 'src: url(data:' + mime.lookup(file.path) + '; base64,' + fontToBase64 + ');}';
+      css += 'src: url(\'data:' + mime.lookup(file.path) + '; base64,' + fontToBase64 + '\');}';
 
       file.contents = new Buffer(css);
       file.path = gutil.replaceExtension(file.path, '.css');

--- a/test/fixtures/myfont.css
+++ b/test/fixtures/myfont.css
@@ -1,1 +1,1 @@
-@font-face { font-family: myfont; src: url(data:application/x-font-ttf; base64,);}
+@font-face { font-family: 'myfont'; src: url('data:application/x-font-ttf; base64,');}


### PR DESCRIPTION
Fixing 2 problems I ran into using the plugin:
- Add quotes around font family name, and font base 64 url: I'm working with [stylus](https://github.com/stylus/stylus) css preprocessor, and files won't compile correctly without them.
- Add a `extrabold` style rule

Hope you'll find this helpfull.
