### PR TITLE
SCSS bugfix

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,11 +24,12 @@ module.exports = function() {
       var fontToBase64 = new Buffer(file.contents).toString('base64'),
           fileName = path.basename(file.path, path.extname(file.path)),
           styleRules = {
-            black:      "font-weight: 800; ",
+            black:      "font-weight: 900; ",
             bold:       "font-weight: 700; ",
-            semibold:   "font-weight: 600; ",
+            medium:     "font-weight: 500; ",
             regular:    "font-weight: 400; ",
-            light:      "font-weight: 200; ",
+            light:      "font-weight: 300; ",
+            thin:       "font-weight: 200; ",
             italic:     "font-style: italic; "
           },
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var fs      = require('fs'),
 module.exports = function() {
   "use strict";
 
-  function gulpSimpleFont64(file, enc, callback) {
+  return through.obj(function(file, enc, callback) {
 
     // Do nothing if no contents
     if (file.isNull()) {
@@ -24,12 +24,12 @@ module.exports = function() {
       var fontToBase64 = new Buffer(file.contents).toString('base64'),
           fileName = path.basename(file.path, path.extname(file.path)),
           styleRules = {
-            black:      "font-weight: 800;",
-            bold:       "font-weight: 700;",
-            semibold:   "font-weight: 600;",
-            regular:    "font-weight: 400;",
-            light:      "font-weight: 200;",
-            italic:     "font-style: italic;"
+            black:      "font-weight: 800; ",
+            bold:       "font-weight: 700; ",
+            semibold:   "font-weight: 600; ",
+            regular:    "font-weight: 400; ",
+            light:      "font-weight: 200; ",
+            italic:     "font-style: italic; "
           },
 
           // Filenames should be of the style: FontFamily-Style1-Style2...
@@ -39,19 +39,17 @@ module.exports = function() {
 
       css += fontAttrs.map(function(attr) {
         // Format our font attributes
-        return attr.toLowerCase();  
+        return attr.toLowerCase();
       }).reduce(function(prev, attr) {
         return styleRules[attr] ? prev + ' ' + styleRules[attr] : prev;
       }, String());
 
-      css += 'src: url(data:' + mime.lookup(file.path) + '; base64,' + fontToBase64 + ');}';
+      css += 'src: url(data:' + mime.lookup(file.path) + ';base64,' + fontToBase64 + ');}';
 
       file.contents = new Buffer(css);
       file.path = gutil.replaceExtension(file.path, '.css');
 
       return callback(null, file);
     }
-  };
-
-  return through.obj(gulpSimpleFont64);
+  });
 };

--- a/test/fixtures/myfont.css
+++ b/test/fixtures/myfont.css
@@ -1,1 +1,1 @@
-@font-face { font-family: myfont; src: url(data:application/x-font-ttf; base64,);}
+@font-face { font-family: myfont; src: url(data:application/x-font-ttf;base64,);}


### PR DESCRIPTION
got an error when preprocessing the base64 font-face with SCSS 

``` js
css += 'src: url(data:' + mime.lookup(file.path) + '; base64,' + fontToBase64 + ');}';
```

because of the space between the filetype and the base64 string, scss is thinking we are presenting an list...
